### PR TITLE
Refactor chat components to use callbacks

### DIFF
--- a/src/pages/chats/components/ChatContainer.tsx
+++ b/src/pages/chats/components/ChatContainer.tsx
@@ -1,4 +1,4 @@
-import {Session, getMillisecondTimestamp} from "nostr-double-ratchet/src"
+import {getMillisecondTimestamp} from "nostr-double-ratchet/src"
 import {useLayoutEffect, useRef, useState, useEffect} from "react"
 import ErrorBoundary from "@/shared/components/ui/ErrorBoundary"
 import Message, {MessageType} from "../message/Message"
@@ -7,14 +7,13 @@ import {SortedMap} from "@/utils/SortedMap/SortedMap"
 
 interface ChatContainerProps {
   messages: SortedMap<string, MessageType>
-  session: Session
   sessionId: string
   onReply: (message: MessageType) => void
   showAuthor?: boolean
   isPublicChat?: boolean
   initialLoadDone?: boolean
   showNoMessages?: boolean
-  onSendReaction?: (messageId: string, emoji: string) => Promise<void>
+  onSendReaction: (messageId: string, emoji: string) => Promise<void>
   reactions?: Record<string, Record<string, string>>
 }
 
@@ -22,7 +21,6 @@ const root = document.documentElement
 
 const ChatContainer = ({
   messages,
-  session,
   sessionId,
   onReply,
   showAuthor = false,
@@ -149,7 +147,6 @@ const ChatContainer = ({
                         message={message}
                         isFirst={messageIndex === 0}
                         isLast={messageIndex === group.length - 1}
-                        session={session}
                         sessionId={sessionId}
                         onReply={() => onReply(message)}
                         showAuthor={showAuthor}

--- a/src/pages/chats/message/Message.tsx
+++ b/src/pages/chats/message/Message.tsx
@@ -1,4 +1,4 @@
-import {getMillisecondTimestamp, Rumor, Session} from "nostr-double-ratchet/src"
+import {getMillisecondTimestamp, Rumor} from "nostr-double-ratchet/src"
 import MessageReactionButton from "../reaction/MessageReactionButton"
 import MessageReactions from "../reaction/MessageReactions"
 import {Avatar} from "@/shared/components/user/Avatar"
@@ -6,7 +6,6 @@ import HyperText from "@/shared/components/HyperText"
 import {shouldHideAuthor} from "@/utils/visibility"
 import {Name} from "@/shared/components/user/Name"
 import {useMemo, useEffect, useState} from "react"
-import {useEventsStore} from "@/stores/events"
 import ReplyPreview from "./ReplyPreview"
 import classNames from "classnames"
 import {Link} from "react-router"
@@ -22,11 +21,10 @@ type MessageProps = {
   message: MessageType
   isFirst: boolean
   isLast: boolean
-  session: Session
   sessionId: string
   onReply?: () => void
   showAuthor?: boolean
-  onSendReaction?: (messageId: string, emoji: string) => Promise<void>
+  onSendReaction: (messageId: string, emoji: string) => Promise<void>
   reactions?: Record<string, string>
 }
 
@@ -75,7 +73,6 @@ const Message = ({
   message,
   isFirst,
   isLast,
-  session,
   sessionId,
   onReply,
   showAuthor = false,
@@ -83,16 +80,15 @@ const Message = ({
   reactions: propReactions,
 }: MessageProps) => {
   const isUser = message.sender === "user"
-  const {events} = useEventsStore()
   const [localReactions, setLocalReactions] = useState<Record<string, string>>(
-    propReactions || {}
+    propReactions || message.reactions || {}
   )
   const isShortEmoji = useMemo(
     () => EMOJI_REGEX.test(message.content?.trim() ?? ""),
     [message.content]
   )
 
-  const sessionReactions = events.get(sessionId)?.get(message.id)?.reactions || {}
+  const sessionReactions = localReactions
 
   // Set up reaction subscription
   useEffect(() => {
@@ -159,7 +155,6 @@ const Message = ({
         {isUser && (
           <MessageReactionButton
             messageId={message.id}
-            sessionId={sessionId}
             isUser={isUser}
             onReply={onReply}
             onSendReaction={onSendReaction}
@@ -211,7 +206,6 @@ const Message = ({
         {!isUser && (
           <MessageReactionButton
             messageId={message.id}
-            sessionId={sessionId}
             isUser={isUser}
             onReply={onReply}
             onSendReaction={onSendReaction}

--- a/src/pages/chats/private/PrivateChat.tsx
+++ b/src/pages/chats/private/PrivateChat.tsx
@@ -9,7 +9,7 @@ import {useEventsStore} from "@/stores/events"
 import {useEffect, useState} from "react"
 
 const Chat = ({id}: {id: string}) => {
-  const {sessions, updateLastSeen} = useSessionsStore()
+  const {sessions, updateLastSeen, sendMessage} = useSessionsStore()
   const {events} = useEventsStore()
   const [haveReply, setHaveReply] = useState(false)
   const [haveSent, setHaveSent] = useState(false)
@@ -64,14 +64,22 @@ const Chat = ({id}: {id: string}) => {
 
   const messages = events.get(id) ?? new SortedMap<string, MessageType>([], comparator)
 
+  const handleSendReaction = async (messageId: string, emoji: string) => {
+    try {
+      await sendMessage(id, emoji, messageId, true)
+    } catch (err) {
+      console.error("Error sending reaction:", err)
+    }
+  }
+
   return (
     <>
       <PrivateChatHeader id={id} messages={messages} />
       <ChatContainer
         messages={messages}
-        session={session}
         sessionId={id}
         onReply={setReplyingTo}
+        onSendReaction={handleSendReaction}
       />
       <MessageForm id={id} replyingTo={replyingTo} setReplyingTo={setReplyingTo} />
     </>

--- a/src/pages/chats/public/PublicChat.tsx
+++ b/src/pages/chats/public/PublicChat.tsx
@@ -262,8 +262,7 @@ const PublicChat = () => {
       <PublicChatHeader channelId={id || ""} />
       <ChatContainer
         messages={messages}
-        session={session} // TODO: remove this when fixing reactions
-        sessionId={id || ""} // TODO: remove this when fixing reactions
+        sessionId={id || ""}
         onReply={setReplyingTo}
         showAuthor={true}
         isPublicChat={true}

--- a/src/pages/chats/reaction/MessageReactionButton.tsx
+++ b/src/pages/chats/reaction/MessageReactionButton.tsx
@@ -1,17 +1,13 @@
 import {FloatingEmojiPicker} from "@/shared/components/emoji/FloatingEmojiPicker"
 import {RiHeartAddLine, RiReplyLine} from "@remixicon/react"
-import {useSessionsStore} from "@/stores/sessions"
-import {NDKEventFromRawEvent} from "@/utils/nostr"
-import {Session} from "nostr-double-ratchet/src"
 import {MouseEvent, useState} from "react"
 import classNames from "classnames"
 
 type MessageReactionButtonProps = {
   messageId: string
-  sessionId: string
   isUser: boolean
   onReply?: () => void
-  onSendReaction?: (messageId: string, emoji: string) => Promise<void>
+  onSendReaction: (messageId: string, emoji: string) => Promise<void>
 }
 
 type EmojiData = {
@@ -21,12 +17,10 @@ type EmojiData = {
 
 const MessageReactionButton = ({
   messageId,
-  sessionId,
   isUser,
   onReply,
   onSendReaction,
 }: MessageReactionButtonProps) => {
-  const {sendMessage} = useSessionsStore()
   const [showReactionsPicker, setShowReactionsPicker] = useState(false)
   const [pickerPosition, setPickerPosition] = useState<{clientY?: number}>({})
 
@@ -38,12 +32,7 @@ const MessageReactionButton = ({
 
   const handleEmojiClick = (emoji: EmojiData) => {
     setShowReactionsPicker(false)
-    if (onSendReaction) {
-      // Use the provided onSendReaction function if available
-      onSendReaction(messageId, emoji.native)
-    } else {
-      sendMessage(sessionId, emoji.native, messageId, true)
-    }
+    onSendReaction(messageId, emoji.native)
   }
 
   return (


### PR DESCRIPTION
## Summary
- remove session prop from `ChatContainer` and `Message`
- require `onSendReaction` handler and update usage
- simplify reaction button implementation
- wire reaction sending in `PrivateChat`
- update public chat to new props

## Testing
- `yarn lint` *(fails: ESLint couldn't find configuration)*
- `yarn test` *(fails: Playwright install prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6847fa194d988326bd4729acff6abd49