### PR TITLE
Implement emoji shortcodes in chats

### DIFF
--- a/src/pages/chats/message/Message.tsx
+++ b/src/pages/chats/message/Message.tsx
@@ -190,7 +190,7 @@ const Message = ({
                   "whitespace-pre-wrap break-words [overflow-wrap:anywhere]"
                 )}
               >
-                <HyperText small={true} truncate={500}>
+                <HyperText event={message} small={true} truncate={500}>
                   {message.content}
                 </HyperText>
               </p>


### PR DESCRIPTION
## Summary
- render custom emoji shortcodes using emoji-mart data
- pass event to HyperText in chat messages so custom emoji tags work

## Testing
- `yarn lint` *(fails: Unexpected any in sessions.ts)*
- `yarn test` *(fails: connection refused on vite server)*

------
https://chatgpt.com/codex/tasks/task_e_684871077f148326846b48cb42f03d30