### PR TITLE
Add delete chat modal

### DIFF
--- a/src/pages/chats/private/DeleteChatModal.tsx
+++ b/src/pages/chats/private/DeleteChatModal.tsx
@@ -1,0 +1,33 @@
+import Modal from "@/shared/components/ui/Modal"
+
+interface DeleteChatModalProps {
+  onClose: () => void
+  onDelete: () => void
+}
+
+const DeleteChatModal = ({onClose, onDelete}: DeleteChatModalProps) => {
+  return (
+    <Modal onClose={onClose} hasBackground={true}>
+      <div className="flex flex-col gap-4 p-4">
+        <h1 className="text-lg font-bold">Delete Chat</h1>
+        <p>Are you sure you want to delete this chat?</p>
+        <div className="flex justify-end gap-2 mt-2">
+          <button className="btn btn-neutral" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            className="btn btn-error"
+            onClick={() => {
+              onDelete()
+              onClose()
+            }}
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+    </Modal>
+  )
+}
+
+export default DeleteChatModal

--- a/src/pages/chats/private/PrivateChatHeader.tsx
+++ b/src/pages/chats/private/PrivateChatHeader.tsx
@@ -6,6 +6,7 @@ import Header from "@/shared/components/header/Header"
 import Dropdown from "@/shared/components/ui/Dropdown"
 import {SortedMap} from "@/utils/SortedMap/SortedMap"
 import {useSessionsStore} from "@/stores/sessions"
+import DeleteChatModal from "./DeleteChatModal"
 import {MessageType} from "../message/Message"
 import socialGraph from "@/utils/socialGraph"
 import {usePublicKey} from "@/stores/user"
@@ -18,13 +19,19 @@ interface PrivateChatHeaderProps {
 
 const PrivateChatHeader = ({id}: PrivateChatHeaderProps) => {
   const [dropdownOpen, setDropdownOpen] = useState(false)
+  const [showDeleteModal, setShowDeleteModal] = useState(false)
   const myPubKey = usePublicKey()
   const navigate = useNavigate()
   const {sessions, deleteSession} = useSessionsStore()
   const session = sessions.get(id)
 
   const handleDeleteChat = () => {
-    if (id && confirm("Delete this chat?")) {
+    setDropdownOpen(false)
+    setShowDeleteModal(true)
+  }
+
+  const confirmDeleteChat = () => {
+    if (id) {
       deleteSession(id)
       navigate("/chats")
     }
@@ -91,6 +98,12 @@ const PrivateChatHeader = ({id}: PrivateChatHeaderProps) => {
                 </li>
               </ul>
             </Dropdown>
+          )}
+          {showDeleteModal && (
+            <DeleteChatModal
+              onClose={() => setShowDeleteModal(false)}
+              onDelete={confirmDeleteChat}
+            />
           )}
         </div>
       </div>

--- a/src/stores/sessions.ts
+++ b/src/stores/sessions.ts
@@ -276,7 +276,7 @@ const store = create<SessionStore>()(
         JSON.parse(localStorage.getItem("sessions") || "null")
       ),
       version: 1,
-      migrate: async (oldData: any, version) => {
+      migrate: async (oldData: unknown, version) => {
         if (version === 0 && oldData) {
           const data = {
             version: 1,


### PR DESCRIPTION
## Summary
- add DeleteChatModal component for confirmations
- use DeleteChatModal in PrivateChatHeader
- fix lint error in session store

## Testing
- `yarn lint`
- `yarn test` *(fails: TimeoutError & http proxy error)*

------
https://chatgpt.com/codex/tasks/task_e_6848712074608326bf7b7d0bcf599d9d